### PR TITLE
Removing HTML tags from index.md

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,13 @@
 </div><!--  / #heroimage /  -->
 
 <div id="contents" class="{{ page.main_content_class }}">
+<div class="section article">
+<div class="inner">
+<div class="section-content no-header">
 {{ content }}
+</div><!-- section-content -->
+</div><!-- inner -->
+</div><!-- section article -->
 </div><!--  / #contents  /-->
 
 <aside><div id="footer-logo">builderscon</div></aside>

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -14,9 +14,14 @@ fieldset, img {
 	border: 0;
 }
 
-address, caption, cite, code, dfn, em, strong, th, var {
+address, caption, cite, code, dfn, em, th, var {
 	font-style: normal;
 	font-weight: normal;
+}
+
+strong {
+	font-weight: bold;
+	line-height: inherit;
 }
 
 ol, ul {

--- a/index.md
+++ b/index.md
@@ -2,30 +2,15 @@
 layout: default
 main_content_class: index
 ---
-<div class="section article">
-<div class="inner">
-<div class="section-content no-header">
 
-<h1>Welcome to builderscon</h1>
+# Welcome to builderscon
 
-<p>builderscon is a "festival (お祭り)" for geeks who are passionate about technology.</p>
+builderscon is a "festival (お祭り)" for geeks who are passionate about technology.
 
-<p>It's about passion for tech, a conference for all the people who love tech. builderscon grew out of a massively successful community driven polyglot event known as "YAPC::Asia Tokyo" which ran between 2006 and 2015.</p>
+It's about passion for tech, a conference for all the people who love tech. builderscon grew out of a massively successful community driven polyglot event known as "YAPC::Asia Tokyo" which ran between 2006 and 2015.
 
-<p>We are planning the first instance to be held on <b>December 2016</b></p>
+We are planning the first instance to be held on **December 2016**
 
-</div><!-- section-content -->
-</div><!-- inner -->
-</div><!-- section article -->
+# Join Our Slack Team
 
-<div class="section article">
-<div class="inner">
-<div class="section-content no-header">
-
-<h1>Join Our Slack Team</h1>
-
-<p>You can <a href="https://slack-invite-dot-builderscon-1248.appspot.com/">invite yourself and join our Slack team!</a></p>
-
-</div><!-- section-content -->
-</div><!-- inner -->
-</div><!-- section article -->
+You can [invite yourself and join our Slack team!](https://slack-invite-dot-builderscon-1248.appspot.com/)


### PR DESCRIPTION
So that we only care about its markdown going forward.

The generated index.html looks slightly different - the "Join Slack" section is now included in the same section as "Welcome". If that should be better separated, let me know.
- [Before](http://res.cloudinary.com/dlze0abrr/image/upload/v1468650948/2016-07-16_14h33_41_l6kq0v.png)
- [After](http://res.cloudinary.com/dlze0abrr/image/upload/v1468650953/2016-07-16_14h33_34_pchyvv.png)

assets/css/common.css -> &lt;strong&gt; needs styling, as its used in markdown **
